### PR TITLE
Launch notify-send not from a specific path

### DIFF
--- a/parts/updateTray.go
+++ b/parts/updateTray.go
@@ -119,7 +119,7 @@ func UpdateTray(c *imap.Client, notify chan bool, name string) {
 
 		// And send them with notify-send!
 		title := fmt.Sprintf("%s has new mail (%d unseen)", name, len(unseenMessages))
-		sh := exec.Command("/usr/bin/notify-send",
+		sh := exec.Command("notify-send",
 			"-i", "notification-message-email",
 			"-c", "email",
 			title, notification)


### PR DESCRIPTION
You can never be sure that `notify-send` will be available exactly at `/usr/bin/`. So why hard code it?